### PR TITLE
mysql fix for layers different from aufs

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+find /var/lib/mysql -type f -exec touch {} \;
+
 echo '[+] Starting mysql...'
 service mysql start
 


### PR DESCRIPTION
This allows mysql to start correctly even on non aufs layer.
Tested on MacOS High Sierra 10.13.3.

![fix](https://user-images.githubusercontent.com/13421144/35476469-c84374a0-03b0-11e8-9cce-cd81d62d5874.png)

Fixes #5 