### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-FROM debian:9.2
+# Use a more recent Debian base image
+FROM debian:stretch
+
+
 
 LABEL maintainer "opsxcq@strm.sh"
 


### PR DESCRIPTION
older code dont complie in jenkins saying error outdated docker so this would help 

# Use a more recent Debian base image
FROM debian:stretch

# ... The rest of your Dockerfile